### PR TITLE
fix: errors deallocating track info

### DIFF
--- a/CompassSDK/Info.plist
+++ b/CompassSDK/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.16.0</string>
+	<string>2.16.1</string>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 </dict>

--- a/CompassSDK/Tracker/Core/CompassTracker.swift
+++ b/CompassSDK/Tracker/Core/CompassTracker.swift
@@ -323,8 +323,12 @@ extension CompassTracker: ConversionsProvider {
 
 internal extension CompassTracker {
     func getTrackingData(for conversion: String? = nil, tick: Int? = 0, _ completion: @escaping (IngestTrackInfo) -> ()) {
-        getScrollPercent { [self] scrollPercent in
-            var finalTrackInfo = self.trackInfo
+        let trackInfoCopy = self.trackInfo
+        
+        getScrollPercent { [weak self] scrollPercent in
+            guard let self else { return }
+            
+            var finalTrackInfo = trackInfoCopy
             
             if let scrollPercent = scrollPercent, scrollPercent > (finalTrackInfo.scrollPercent ?? 0) {
                 finalTrackInfo.scrollPercent = scrollPercent

--- a/MarfeelSDK-iOS.podspec
+++ b/MarfeelSDK-iOS.podspec
@@ -16,7 +16,7 @@ Pod::Spec.new do |spec|
   #
 
   spec.name         = "MarfeelSDK-iOS"
-  spec.version      = "2.16.0"
+  spec.version      = "2.16.1"
   spec.summary      = "iOS version of MarfeelSDK."
 
 


### PR DESCRIPTION
```
Crashed: com.apple.root.utility-qos
0  libswiftCore.dylib             0x2f7178 _swift_release_dealloc + 16
1  libswiftCore.dylib             0x2f8060 bool swift::RefCounts<swift::RefCountBitsT<(swift::RefCountInlinedness)1>>::doDecrementSlow<(swift::PerformDeinit)1>(swift::RefCountBitsT<(swift::RefCountInlinedness)1>, unsigned int) + 184
2  Sport                          0xa7ecc4 destroy for IngestTrackInfo + 4318276804 (<compiler-generated>:4318276804)
3  Sport                          0xa7c530 outlined destroy of IngestTrackInfo + 4318266672 (<compiler-generated>:4318266672)
4  Sport                          0xa7d6b4 specialized closure #1 in CompassTracker.getTrackingData(for:tick:_:) + 346 (CompassTracker.swift:346)
5  Sport                          0xa7da58 specialized CompassTracker.getTrackingData(for:tick:_:) + 347 (CompassTracker.swift:347)
6  Sport                          0xa7aa10 closure #1 in closure #1 in CompassTracker.createOperation(conversion:dispatchDate:dispatchGroup:) + 4318259728
7  Sport                          0x18178 thunk for @escaping @callee_guaranteed () -> () + 4307370360 (<compiler-generated>:4307370360)
8  libdispatch.dylib              0x637a8 _dispatch_call_block_and_release + 24
9  libdispatch.dylib              0x64780 _dispatch_client_callout + 16
10 libdispatch.dylib              0x48d88 _dispatch_root_queue_drain + 616
11 libdispatch.dylib              0x49430 _dispatch_worker_thread2 + 160
12 libsystem_pthread.dylib        0x1b94 _pthread_wqthread + 224
13 libsystem_pthread.dylib        0x1720 start_wqthread + 8
```