### PR TITLE
fix: long tasks background crash

### DIFF
--- a/CompassSDK/Info.plist
+++ b/CompassSDK/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.18.2</string>
+	<string>2.18.3</string>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 </dict>

--- a/MarfeelSDK-iOS.podspec
+++ b/MarfeelSDK-iOS.podspec
@@ -16,7 +16,7 @@ Pod::Spec.new do |spec|
   #
 
   spec.name         = "MarfeelSDK-iOS"
-  spec.version      = "2.18.2"
+  spec.version      = "2.18.3"
   spec.summary      = "iOS version of MarfeelSDK."
 
 


### PR DESCRIPTION
* Separate background tasks origin vs fallback
* each background tasks now hoistes it's task id, before was store in an instance field, introducing race conditions and bad cleanups
* Timeout for primary ping
* Fire-and-forget fallback
* Weak self everywhere
* Async in timers
* Thread-safe origin