### PR TITLE
MF-8535/cdp-for-ios

### DIFF
--- a/CompassSDK/CDP/Cdp.swift
+++ b/CompassSDK/CDP/Cdp.swift
@@ -1,0 +1,125 @@
+//
+//  Cdp.swift
+//  CompassSDK
+//
+//  Public CDP facade + singleton.
+//
+//  The CDP is gated behind two independent conditions: the `enableCdp` opt-in (set at
+//  CompassTracker.initialize) AND personalization consent. When either is missing the
+//  whole subsystem is inert and no network calls are made.
+//
+
+import Foundation
+
+public protocol CdpTracking: AnyObject {
+    /// Link a known identifier (login, CRM id, email hash…).
+    func cdpDoIdentityLink(type: String, value: String, isDeterministic: Bool)
+    /// CDP contribution to the beacon: `{ masterId, rfv, cohorts }`.
+    func getCdpData() -> CdpData
+    /// Current master_id (nil if unresolved).
+    func getCdpMasterId() -> String?
+
+    func addCdpSegment(_ segment: String)
+    func removeCdpSegment(_ segment: String)
+    func setCdpSegments(_ segments: [String])
+    func clearCdpSegments()
+    func getCdpSegments() -> [String]
+
+    /// Fetch all meters (stale-while-revalidate). The completion runs off the main thread.
+    func getMeterSnapshot(completion: @escaping ([MeterState]) -> Void)
+    /// Read the in-memory meter mirror.
+    func getMeter(_ name: String) -> MeterState?
+    func listMeters() -> [MeterState]
+    /// Increment a meter. `.failure(MeterNotFoundError)` when the meter is not configured.
+    func incrementMeter(_ name: String, completion: @escaping (Result<MeterState?, Error>) -> Void)
+}
+
+public extension CdpTracking {
+    func cdpDoIdentityLink(type: String, value: String) {
+        cdpDoIdentityLink(type: type, value: value, isDeterministic: false)
+    }
+}
+
+public enum Cdp {
+    public static var shared: CdpTracking { CdpTracker.shared }
+}
+
+internal final class CdpTracker: CdpTracking {
+    static let shared = CdpTracker()
+
+    private let manager: CdpManager
+    private let meteredCounter: MeteredCounter
+
+    init(
+        api: CdpApiClient = CdpApiClient(),
+        defaults: UserDefaults = UserDefaults(suiteName: CDP_MIRROR_SUITE_NAME) ?? .standard,
+        host: CdpHost = CompassTracker.shared
+    ) {
+        let manager = CdpManager(api: api, host: host, segmentsStore: CdpSegmentsStore(defaults: defaults))
+        self.manager = manager
+        self.meteredCounter = MeteredCounter(cdpManager: manager, metersStore: CdpMetersStore(defaults: defaults), api: api)
+
+        manager.onMasterIdChanged = { [weak self] _, _ in self?.meteredCounter.reset() }
+        registerIdentityResolvedWork(host: host)
+    }
+
+    /// Once-per-visit work, fired when identity first becomes available under consent.
+    /// Unlike the Android port this is wired internally (the SDK already knows where to
+    /// read user-vars and the timezone), so `initialize` doesn't pass it in.
+    private func registerIdentityResolvedWork(host: CdpHost) {
+        manager.onIdentityResolved { [weak self] in
+            guard let self = self else { return }
+            self.manager.reconcileSegments()
+            var properties = host.cdpUserVars
+            properties["timezone"] = TimeZone.current.identifier
+            self.manager.updateProfile(properties)
+            self.meteredCounter.seed()
+            self.meteredCounter.cleanupExpiredMeters(
+                account: self.manager.currentAccountIdString(),
+                activeMid: self.manager.currentMasterId()
+            )
+        }
+    }
+
+    // MARK: - Public surface
+
+    func cdpDoIdentityLink(type: String, value: String, isDeterministic: Bool) {
+        manager.linkIdentity(type: type, value: value, isDeterministic: isDeterministic)
+    }
+
+    func getCdpData() -> CdpData { manager.getData() }
+
+    func getCdpMasterId() -> String? { manager.currentMasterId() }
+
+    func addCdpSegment(_ segment: String) { manager.addSegment(segment) }
+    func removeCdpSegment(_ segment: String) { manager.removeSegment(segment) }
+    func setCdpSegments(_ segments: [String]) { manager.replaceSegments(segments) }
+    func clearCdpSegments() { manager.clearSegments() }
+    func getCdpSegments() -> [String] { manager.getCdpSegments() }
+
+    func getMeterSnapshot(completion: @escaping ([MeterState]) -> Void) { meteredCounter.getMeterSnapshot(completion: completion) }
+    func getMeter(_ name: String) -> MeterState? { meteredCounter.get(name) }
+    func listMeters() -> [MeterState] { meteredCounter.list() }
+    func incrementMeter(_ name: String, completion: @escaping (Result<MeterState?, Error>) -> Void) { meteredCounter.increment(name: name, completion: completion) }
+
+    // MARK: - Internal hooks (driven by CompassTracker)
+
+    /// Cold-start / enable entry point: resolve identity right away.
+    func start() {
+        meteredCounter.invalidate()
+        manager.resolveIdentity()
+    }
+
+    func onNewPage() {
+        meteredCounter.invalidate()
+        manager.resolveIdentity()
+    }
+
+    func onConsentChanged() {
+        manager.onConsentChanged()
+    }
+
+    func onSiteUserId(_ userId: String) {
+        manager.linkIdentity(type: "registered_user_id", value: userId, isDeterministic: true)
+    }
+}

--- a/CompassSDK/CDP/Cdp.swift
+++ b/CompassSDK/CDP/Cdp.swift
@@ -69,6 +69,9 @@ internal final class CdpTracker: CdpTracking {
     private func registerIdentityResolvedWork(host: CdpHost) {
         manager.onIdentityResolved { [weak self] in
             guard let self = self else { return }
+            // Bridge legacy `useg` segments into the CDP store, then reconcile so the
+            // unioned set is what gets pushed as segments_add (matches web ordering).
+            self.manager.mergeLegacySegments()
             self.manager.reconcileSegments()
             var properties = host.cdpUserVars
             properties["timezone"] = TimeZone.current.identifier

--- a/CompassSDK/CDP/CdpApiClient.swift
+++ b/CompassSDK/CDP/CdpApiClient.swift
@@ -1,0 +1,152 @@
+//
+//  CdpApiClient.swift
+//  CompassSDK
+//
+//  URLSession networking for the CDP. Mirrors CdpApiClient.kt.
+//
+//  All identity/profile calls are fail-open: any error / non-2xx / unparseable body
+//  resolves to UNKNOWN_CDP_IDENTITY rather than surfacing an error. Trailing slashes
+//  on the identity paths are part of the contract and must be preserved (so the URLs
+//  are built by string concatenation, not appendingPathComponent).
+//
+
+import Foundation
+import UIKit
+
+internal struct IncrementResult {
+    let status: Int
+    let state: MeterState?
+}
+
+internal class CdpApiClient {
+    private let session: URLSession
+    private let baseUrl: URL?
+
+    init(session: URLSession = .shared, baseUrl: URL? = TrackingConfig.shared.endpoint) {
+        self.session = session
+        self.baseUrl = baseUrl
+    }
+
+    private var baseString: String {
+        guard let string = baseUrl?.absoluteString else { return "" }
+        return string.hasSuffix("/") ? String(string.dropLast()) : string
+    }
+
+    private var userAgent: String {
+        let codeVersion = Bundle.compassSDK?.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String ?? "unknown"
+        let deviceType = UIDevice.current.userInterfaceIdiom == .pad ? "tablet" : "mobile"
+        return "Marfeel-iOS-SDK/\(codeVersion) (\(UIDevice.current.model)) \(deviceType)"
+    }
+
+    // MARK: - Identity / profile
+
+    func resolve(_ params: CdpResolveParams, completion: @escaping (CdpIdentityResponse) -> Void) {
+        postIdentity(path: CDP_IDENTITY_RESOLVE_PATH, params: params, completion: completion)
+    }
+
+    func link(_ params: CdpLinkParams, completion: @escaping (CdpIdentityResponse) -> Void) {
+        postIdentity(path: CDP_IDENTITY_LINK_PATH, params: params, completion: completion)
+    }
+
+    func update(_ params: CdpProfileUpdateParams, completion: @escaping (CdpIdentityResponse) -> Void) {
+        postIdentity(path: CDP_IDENTITY_UPDATE_PATH, params: params, completion: completion)
+    }
+
+    private func postIdentity<T: Encodable>(path: String, params: T, completion: @escaping (CdpIdentityResponse) -> Void) {
+        guard let url = URL(string: baseString + path), let body = try? JSONEncoder().encode(params) else {
+            completion(UNKNOWN_CDP_IDENTITY)
+            return
+        }
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.httpBody = body
+        request.addValue("application/json; charset=utf-8", forHTTPHeaderField: "Content-Type")
+        request.addValue(userAgent, forHTTPHeaderField: "User-Agent")
+
+        session.dataTask(with: request) { data, response, error in
+            guard error == nil,
+                  let http = response as? HTTPURLResponse, (200..<300).contains(http.statusCode),
+                  let data = data,
+                  let parsed = CdpIdentityResponse.decode(from: data) else {
+                completion(UNKNOWN_CDP_IDENTITY)
+                return
+            }
+            completion(parsed)
+        }.resume()
+    }
+
+    // MARK: - Meters
+
+    func fetchMeters(siteId: String, masterId: String, completion: @escaping ([MeterState]?) -> Void) {
+        guard var components = URLComponents(string: baseString + CDP_METERS_PATH) else {
+            completion(nil)
+            return
+        }
+        components.queryItems = [
+            URLQueryItem(name: "site_id", value: siteId),
+            URLQueryItem(name: "master_id", value: masterId)
+        ]
+        guard let url = components.url else {
+            completion(nil)
+            return
+        }
+        var request = URLRequest(url: url)
+        request.addValue(userAgent, forHTTPHeaderField: "User-Agent")
+
+        session.dataTask(with: request) { data, response, error in
+            guard error == nil,
+                  let http = response as? HTTPURLResponse, (200..<300).contains(http.statusCode),
+                  let data = data else {
+                // Fail-open: SWR keeps the last-good mirror.
+                completion(nil)
+                return
+            }
+            guard let root = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+                  let meters = root["meters"] as? [[String: Any]] else {
+                // Non-object / non-array meters → treat as empty list, not an error.
+                completion([])
+                return
+            }
+            completion(meters.map { MeterState.from(json: $0) })
+        }.resume()
+    }
+
+    func incrementMeter(name: String, siteId: String, masterId: String, completion: @escaping (IncrementResult) -> Void) {
+        let encodedName = name.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? name
+        guard var components = URLComponents(string: baseString + CDP_METERS_PATH + "/\(encodedName)/increment") else {
+            completion(IncrementResult(status: 0, state: nil))
+            return
+        }
+        components.queryItems = [
+            URLQueryItem(name: "site_id", value: siteId),
+            URLQueryItem(name: "master_id", value: masterId)
+        ]
+        guard let url = components.url else {
+            completion(IncrementResult(status: 0, state: nil))
+            return
+        }
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.httpBody = Data()
+        request.addValue("application/json; charset=utf-8", forHTTPHeaderField: "Content-Type")
+        request.addValue(userAgent, forHTTPHeaderField: "User-Agent")
+
+        session.dataTask(with: request) { data, response, error in
+            if error != nil {
+                completion(IncrementResult(status: 0, state: nil))
+                return
+            }
+            guard let http = response as? HTTPURLResponse else {
+                completion(IncrementResult(status: 0, state: nil))
+                return
+            }
+            // A 404 must reach the caller so it can surface MeterNotFoundError.
+            guard (200..<300).contains(http.statusCode), let data = data else {
+                completion(IncrementResult(status: http.statusCode, state: nil))
+                return
+            }
+            let state = (try? JSONSerialization.jsonObject(with: data) as? [String: Any]).flatMap { $0 }.map { MeterState.from(json: $0) }
+            completion(IncrementResult(status: http.statusCode, state: state))
+        }.resume()
+    }
+}

--- a/CompassSDK/CDP/CdpConstants.swift
+++ b/CompassSDK/CDP/CdpConstants.swift
@@ -1,0 +1,26 @@
+//
+//  CdpConstants.swift
+//  CompassSDK
+//
+//  CDP subsystem constants. Mirrors CdpConstants.kt in the Android SDK.
+//
+
+import Foundation
+
+internal let CDP_IDENTITY_RESOLVE_PATH = "/cdp/identity/resolve/"
+internal let CDP_IDENTITY_LINK_PATH = "/cdp/identity/link/"
+internal let CDP_IDENTITY_UPDATE_PATH = "/cdp/identity/update/"
+internal let CDP_METERS_PATH = "/cdp/meters"
+
+internal let LOCAL_MID_SENTINEL = "local"
+
+/// 180-day TTL for the per-(account, master_id) mirror store. Matches the backend's
+/// anonymous-data TTL ("Scylla DefaultAnonymousTTL").
+internal let CDP_MIRROR_TTL_MS: Int64 = 180 * 24 * 60 * 60 * 1000
+
+/// The "unknown" identity every failed identity/profile call resolves to (fail-open).
+internal let UNKNOWN_CDP_IDENTITY = CdpIdentityResponse(masterId: nil, rfv: nil, cohorts: [])
+
+/// CDP uses "personalization" consent. On iOS this maps to the global consent flag,
+/// which is permissive unless explicitly set to false.
+internal let CDP_MIRROR_SUITE_NAME = "CompassCdpMirror"

--- a/CompassSDK/CDP/CdpDates.swift
+++ b/CompassSDK/CDP/CdpDates.swift
@@ -1,0 +1,47 @@
+//
+//  CdpDates.swift
+//  CompassSDK
+//
+//  ISO-8601 helpers for meter dates. Mirrors CdpDates.kt.
+//
+
+import Foundation
+
+private let isoParsers: [DateFormatter] = {
+    let patterns = [
+        "yyyy-MM-dd'T'HH:mm:ss.SSSXXXXX",
+        "yyyy-MM-dd'T'HH:mm:ssXXXXX",
+        "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'",
+        "yyyy-MM-dd'T'HH:mm:ss'Z'"
+    ]
+    return patterns.map { pattern in
+        let formatter = DateFormatter()
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        formatter.timeZone = TimeZone(identifier: "UTC")
+        formatter.dateFormat = pattern
+        return formatter
+    }
+}()
+
+private let isoFormatter: DateFormatter = {
+    let formatter = DateFormatter()
+    formatter.locale = Locale(identifier: "en_US_POSIX")
+    formatter.timeZone = TimeZone(identifier: "UTC")
+    formatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'"
+    return formatter
+}()
+
+internal func parseIsoDate(_ value: String?) -> Date? {
+    guard let value = value, !value.isEmpty else { return nil }
+    for parser in isoParsers {
+        if let date = parser.date(from: value) {
+            return date
+        }
+    }
+    return nil
+}
+
+internal func formatIsoDate(_ date: Date?) -> String? {
+    guard let date = date else { return nil }
+    return isoFormatter.string(from: date)
+}

--- a/CompassSDK/CDP/CdpManager.swift
+++ b/CompassSDK/CDP/CdpManager.swift
@@ -1,0 +1,290 @@
+//
+//  CdpManager.swift
+//  CompassSDK
+//
+//  CDP identity state machine + segments + properties.
+//
+//  iOS has no coroutines, so the per-session memoization (Android's Deferred/Mutex) is
+//  a serial DispatchQueue guarding the resolve state plus a list of pending completions
+//  that share a single in-flight network call. The host (CompassTracker) is reached
+//  through the `CdpHost` protocol rather than a bag of closures.
+//
+
+import Foundation
+
+/// Everything the CDP needs from the surrounding tracker. Keeps the tracker the single
+/// owner of persistence, session, consent and account config.
+internal protocol CdpHost: AnyObject {
+    var cdpEnabled: Bool { get }
+    var cdpAccountId: Int? { get }
+    var cdpUserId: String { get }
+    var cdpSessionId: String { get }
+    var cdpConsent: Bool? { get }
+    var cdpUserVars: [String: String] { get }
+    func cdpReadMasterId() -> String?
+    func cdpWriteMasterId(_ id: String) -> String?
+    func cdpReadCachedIdentity(sessionId: String) -> CdpCachedIdentity?
+    func cdpWriteCachedIdentity(rfv: CdpRfv?, cohorts: [Int], sessionId: String)
+}
+
+internal final class CdpManager {
+    private let api: CdpApiClient
+    private let host: CdpHost
+    private let segmentsStore: CdpSegmentsStore
+
+    /// Fired (old, new) whenever the master_id changes. Wired to reset the meter mirror.
+    var onMasterIdChanged: ((String?, String) -> Void)?
+
+    private let queue = DispatchQueue(label: "com.marfeel.cdp.manager")
+
+    private enum ResolveState { case idle, inFlight, done }
+    private var resolveState: ResolveState = .idle
+    private var memoSessionId: String?
+    private var pending: [() -> Void] = []
+
+    private var identityResolved = false
+    private var oneShotCallback: (() -> Void)?
+
+    init(api: CdpApiClient, host: CdpHost, segmentsStore: CdpSegmentsStore) {
+        self.api = api
+        self.host = host
+        self.segmentsStore = segmentsStore
+    }
+
+    // MARK: - Gating & accessors
+
+    /// Consent for the "personalization" purpose: enabled AND consent not explicitly false.
+    func hasConsent() -> Bool { host.cdpEnabled && host.cdpConsent != false }
+
+    func currentMasterId() -> String? { host.cdpReadMasterId() }
+
+    func currentAccountIdString() -> String? { host.cdpAccountId.map(String.init) }
+
+    private var storageMid: String { host.cdpReadMasterId() ?? LOCAL_MID_SENTINEL }
+
+    // MARK: - One-shot
+
+    func onIdentityResolved(_ callback: @escaping () -> Void) {
+        queue.async {
+            self.oneShotCallback = callback
+            self.maybeFireOneShotLocked()
+        }
+    }
+
+    /// MUST be called on `queue`.
+    private func maybeFireOneShotLocked() {
+        guard !identityResolved else { return }
+        if hasConsent() && host.cdpReadMasterId() != nil {
+            identityResolved = true
+            oneShotCallback?()
+        }
+    }
+
+    // MARK: - Identity resolution
+
+    func resolveIdentity(completion: (() -> Void)? = nil) {
+        guard hasConsent() else { completion?(); return }
+        let session = host.cdpSessionId
+
+        queue.async {
+            if session != self.memoSessionId {
+                self.memoSessionId = session
+                self.resolveState = .idle
+                self.identityResolved = false
+            }
+
+            switch self.resolveState {
+            case .done:
+                completion?()
+            case .inFlight:
+                completion.map { self.pending.append($0) }
+            case .idle:
+                self.resolveState = .inFlight
+                completion.map { self.pending.append($0) }
+                self.runResolveLocked(session)
+            }
+        }
+    }
+
+    /// MUST be called on `queue`.
+    private func runResolveLocked(_ session: String) {
+        // Skip the network if we're already resolved (cached identity + master_id).
+        guard host.cdpReadCachedIdentity(sessionId: session) == nil || host.cdpReadMasterId() == nil else {
+            finishResolveLocked()
+            return
+        }
+        guard let siteId = host.cdpAccountId else {
+            finishResolveLocked()
+            return
+        }
+
+        let params = CdpResolveParams(siteId: siteId, cookieId: host.cdpUserId, masterId: host.cdpReadMasterId())
+        api.resolve(params) { [weak self] response in
+            self?.queue.async {
+                self?.applyStateLocked(response, session: session)
+                self?.finishResolveLocked()
+            }
+        }
+    }
+
+    /// MUST be called on `queue`. Marks the resolve done (or idle to retry on failure)
+    /// and drains pending completions.
+    private func finishResolveLocked() {
+        resolveState = host.cdpReadMasterId() != nil ? .done : .idle
+        let callbacks = pending
+        pending = []
+        maybeFireOneShotLocked()
+        callbacks.forEach { $0() }
+    }
+
+    func linkIdentity(type: String, value: String, isDeterministic: Bool, completion: (() -> Void)? = nil) {
+        guard hasConsent() else { completion?(); return }
+        resolveIdentity { [weak self] in
+            guard let self = self, let siteId = self.host.cdpAccountId else { completion?(); return }
+            let params = CdpLinkParams(
+                siteId: siteId,
+                idType: type,
+                idValue: value,
+                isDeterministic: isDeterministic,
+                masterId: self.host.cdpReadMasterId()
+            )
+            self.api.link(params) { [weak self] response in
+                self?.queue.async {
+                    self?.applyStateLocked(response, session: self?.host.cdpSessionId ?? "")
+                    completion?()
+                }
+            }
+        }
+    }
+
+    func onConsentChanged() {
+        resolveIdentity()
+        queue.async { self.maybeFireOneShotLocked() }
+    }
+
+    /// Single write path for every endpoint response. MUST be called on `queue`.
+    private func applyStateLocked(_ response: CdpIdentityResponse, session: String) {
+        if let masterId = response.masterId, !masterId.isEmpty {
+            let old = host.cdpWriteMasterId(masterId)
+            transferCdpSegments(oldId: old, newId: masterId)
+            if old != masterId { onMasterIdChanged?(old, masterId) }
+        }
+        host.cdpWriteCachedIdentity(rfv: response.rfv, cohorts: response.cohorts, sessionId: session)
+        maybeFireOneShotLocked()
+    }
+
+    // MARK: - Properties
+
+    func updateProfile(_ properties: [String: String], completion: (() -> Void)? = nil) {
+        guard hasConsent(), let masterId = host.cdpReadMasterId(), let siteId = host.cdpAccountId, !properties.isEmpty else {
+            completion?()
+            return
+        }
+        let params = CdpProfileUpdateParams(siteId: siteId, masterId: masterId, properties: properties)
+        api.update(params) { [weak self] response in
+            self?.queue.async {
+                self?.applyStateLocked(response, session: self?.host.cdpSessionId ?? "")
+                completion?()
+            }
+        }
+    }
+
+    // MARK: - Segments
+
+    func getCdpSegments() -> [String] {
+        guard host.cdpEnabled else { return [] }
+        return segmentsStore.read(account: currentAccountIdString(), masterId: storageMid)
+    }
+
+    func addSegment(_ segment: String) {
+        mutateSegments { local in local.contains(segment) ? nil : (local + [segment], [segment], nil) }
+    }
+
+    func removeSegment(_ segment: String) {
+        mutateSegments { local in (local.filter { $0 != segment }, nil, [segment]) }
+    }
+
+    func clearSegments() {
+        mutateSegments { local in (local: [], add: nil, remove: local.isEmpty ? nil : local) }
+    }
+
+    func replaceSegments(_ segments: [String]) {
+        mutateSegments { previous in
+            let deduped = self.dedup(segments)
+            // Diff against the previous LOCAL snapshot, not the backend.
+            let adds = deduped.filter { !previous.contains($0) }
+            let removes = previous.filter { !deduped.contains($0) }
+            return (deduped, adds.isEmpty ? nil : adds, removes.isEmpty ? nil : removes)
+        }
+    }
+
+    /// Local-first segment mutation: compute the new list + delta from the current local
+    /// list, write locally (even pre-consent), then sync the delta. Returning nil from
+    /// `transform` is a no-op (e.g. adding a segment that already exists).
+    private func mutateSegments(_ transform: @escaping (_ local: [String]) -> (local: [String], add: [String]?, remove: [String]?)?) {
+        guard host.cdpEnabled else { return }
+        queue.async {
+            let account = self.currentAccountIdString()
+            let mid = self.storageMid
+            let local = self.segmentsStore.read(account: account, masterId: mid)
+            guard let result = transform(local) else { return }
+            self.segmentsStore.write(account: account, masterId: mid, value: result.local)
+            if result.add != nil || result.remove != nil {
+                self.postSegmentChangeLocked(segmentsAdd: result.add, segmentsRemove: result.remove)
+            }
+        }
+    }
+
+    /// Flush local segments as adds (idempotent). Pre-consent removes are not recovered.
+    func reconcileSegments() {
+        guard hasConsent(), let masterId = host.cdpReadMasterId() else { return }
+        queue.async {
+            let local = self.segmentsStore.read(account: self.currentAccountIdString(), masterId: masterId)
+            if !local.isEmpty {
+                self.postSegmentChangeLocked(segmentsAdd: local, segmentsRemove: nil)
+            }
+        }
+    }
+
+    /// MUST be called on `queue`.
+    private func postSegmentChangeLocked(segmentsAdd: [String]?, segmentsRemove: [String]?) {
+        guard hasConsent(), let masterId = host.cdpReadMasterId(), let siteId = host.cdpAccountId else { return }
+        let params = CdpProfileUpdateParams(siteId: siteId, masterId: masterId, segmentsAdd: segmentsAdd, segmentsRemove: segmentsRemove)
+        api.update(params) { [weak self] response in
+            self?.queue.async {
+                self?.applyStateLocked(response, session: self?.host.cdpSessionId ?? "")
+            }
+        }
+    }
+
+    /// Carry the previous bucket's segments into the new master_id's bucket.
+    /// Best-effort — must never bubble up. MUST be called on `queue`.
+    private func transferCdpSegments(oldId: String?, newId: String) {
+        guard let account = currentAccountIdString(), !account.isEmpty else { return }
+        let previousMid = oldId ?? segmentsStore.getActiveMid(account: account) ?? LOCAL_MID_SENTINEL
+        if previousMid == newId {
+            segmentsStore.setActiveMid(account: account, masterId: newId)
+            return
+        }
+        let previous = segmentsStore.read(account: account, masterId: previousMid)
+        let current = segmentsStore.read(account: account, masterId: newId)
+        let union = dedup(current + previous)
+        if !union.isEmpty { segmentsStore.write(account: account, masterId: newId, value: union) }
+        segmentsStore.clear(account: account, masterId: previousMid)
+        segmentsStore.setActiveMid(account: account, masterId: newId)
+        segmentsStore.cleanupExpired(account: account, activeMidOverride: newId)
+    }
+
+    private func dedup(_ items: [String]) -> [String] {
+        var seen = Set<String>()
+        return items.filter { seen.insert($0).inserted }
+    }
+
+    // MARK: - Beacon data
+
+    func getData() -> CdpData {
+        guard host.cdpEnabled else { return CdpData(masterId: nil, rfv: nil, cohorts: []) }
+        let cached = host.cdpReadCachedIdentity(sessionId: host.cdpSessionId)
+        return CdpData(masterId: host.cdpReadMasterId(), rfv: cached?.rfv, cohorts: cached?.cohorts ?? [])
+    }
+}

--- a/CompassSDK/CDP/CdpManager.swift
+++ b/CompassSDK/CDP/CdpManager.swift
@@ -25,6 +25,9 @@ internal protocol CdpHost: AnyObject {
     func cdpWriteMasterId(_ id: String) -> String?
     func cdpReadCachedIdentity(sessionId: String) -> CdpCachedIdentity?
     func cdpWriteCachedIdentity(rfv: CdpRfv?, cohorts: [Int], sessionId: String)
+    /// The legacy (`useg`) segment list — bridged into the CDP store on first resolve.
+    var cdpLegacySegments: [String] { get }
+    func cdpWriteLegacySegments(_ segments: [String])
 }
 
 internal final class CdpManager {
@@ -242,6 +245,29 @@ internal final class CdpManager {
             let local = self.segmentsStore.read(account: self.currentAccountIdString(), masterId: masterId)
             if !local.isEmpty {
                 self.postSegmentChangeLocked(segmentsAdd: local, segmentsRemove: nil)
+            }
+        }
+    }
+
+    /// Bridge the legacy (`useg`) segment store into the CDP store on first identity
+    /// resolve, mirroring the web `mergeLegacySegmentsIntoCdpStorage` union: union the
+    /// legacy list into the CDP store for the resolved master_id, then write the union
+    /// back to the legacy store so both stay in sync. Must run BEFORE `reconcileSegments`
+    /// so the unioned set is what gets pushed as `segments_add`. No-op without a real
+    /// master_id (leaves the legacy list untouched).
+    func mergeLegacySegments() {
+        guard hasConsent() else { return }
+        queue.async {
+            guard let masterId = self.host.cdpReadMasterId() else { return }
+            let account = self.currentAccountIdString()
+            let legacy = self.host.cdpLegacySegments
+            let stored = self.segmentsStore.read(account: account, masterId: masterId)
+            let merged = self.dedup(stored + legacy)
+            if Set(merged) != Set(stored) {
+                self.segmentsStore.write(account: account, masterId: masterId, value: merged)
+            }
+            if Set(merged) != Set(legacy) {
+                self.host.cdpWriteLegacySegments(merged)
             }
         }
     }

--- a/CompassSDK/CDP/MeteredCounter.swift
+++ b/CompassSDK/CDP/MeteredCounter.swift
@@ -1,0 +1,148 @@
+//
+//  MeteredCounter.swift
+//  CompassSDK
+//
+//  Stale-while-revalidate meter mirror + increment. Mirrors MeteredCounter.kt.
+//
+
+import Foundation
+
+internal final class MeteredCounter {
+    private let cdpManager: CdpManager
+    private let metersStore: CdpMetersStore
+    private let api: CdpApiClient
+
+    private let queue = DispatchQueue(label: "com.marfeel.cdp.meters")
+
+    private var meters: [MeterState] = []
+    private var fresh = false
+    private var seeded = false
+    private var inflight = false
+    private var inflightPending: [([MeterState]) -> Void] = []
+
+    init(cdpManager: CdpManager, metersStore: CdpMetersStore, api: CdpApiClient) {
+        self.cdpManager = cdpManager
+        self.metersStore = metersStore
+        self.api = api
+    }
+
+    private func ready() -> Bool { cdpManager.hasConsent() && cdpManager.currentMasterId() != nil }
+
+    // MARK: - Seeding (sync read from persistence)
+
+    func seed() {
+        guard ready() else { return }
+        queue.sync {
+            guard !seeded else { return }
+            runSeedLocked()
+            seeded = true
+        }
+    }
+
+    /// MUST be called on `queue`. Never overwrites an already-populated mirror.
+    private func runSeedLocked() {
+        guard meters.isEmpty else { return }
+        let stored = metersStore.read(account: cdpManager.currentAccountIdString(), masterId: cdpManager.currentMasterId())
+        if meters.isEmpty && !stored.isEmpty { meters = stored }
+    }
+
+    // MARK: - Snapshot (SWR)
+
+    func getMeterSnapshot(completion: @escaping ([MeterState]) -> Void) {
+        guard ready() else {
+            completion(queue.sync { meters })
+            return
+        }
+        queue.async {
+            if !self.seeded { self.runSeedLocked(); self.seeded = true }
+            if self.fresh {
+                completion(self.meters)
+                return
+            }
+            self.inflightPending.append(completion)
+            if self.inflight { return }
+            self.inflight = true
+
+            guard let account = self.cdpManager.currentAccountIdString(),
+                  let masterId = self.cdpManager.currentMasterId() else {
+                self.finishFetchLocked(nil)
+                return
+            }
+            self.api.fetchMeters(siteId: account, masterId: masterId) { [weak self] fetched in
+                self?.queue.async { self?.finishFetchLocked(fetched) }
+            }
+        }
+    }
+
+    /// MUST be called on `queue`.
+    private func finishFetchLocked(_ fetched: [MeterState]?) {
+        if let fetched = fetched {
+            meters = fetched
+            fresh = true
+            persistLocked(fetched)
+        }
+        // Fail-open: a failed fetch keeps the last-good mirror and stays not-fresh.
+        let pending = inflightPending
+        inflightPending = []
+        inflight = false
+        pending.forEach { $0(meters) }
+    }
+
+    // MARK: - Sync reads
+
+    func get(_ name: String) -> MeterState? { queue.sync { meters.first { $0.name == name } } }
+
+    func list() -> [MeterState] { queue.sync { meters } }
+
+    func invalidate() { queue.async { self.fresh = false } }
+
+    func reset() {
+        queue.async {
+            self.meters = []
+            self.fresh = false
+            self.seeded = false
+            self.inflight = false
+            self.inflightPending = []
+        }
+    }
+
+    func cleanupExpiredMeters(account: String?, activeMid: String?) {
+        metersStore.cleanupExpired(account: account, activeMidOverride: activeMid)
+    }
+
+    // MARK: - Increment
+
+    func increment(name: String, completion: @escaping (Result<MeterState?, Error>) -> Void) {
+        guard ready(),
+              let account = cdpManager.currentAccountIdString(),
+              let masterId = cdpManager.currentMasterId() else {
+            completion(.success(nil))
+            return
+        }
+        api.incrementMeter(name: name, siteId: account, masterId: masterId) { [weak self] result in
+            guard let self = self else { completion(.success(nil)); return }
+            self.queue.async {
+                if result.status == 404 {
+                    completion(.failure(MeterNotFoundError(meterName: name)))
+                    return
+                }
+                guard let state = result.state else {
+                    completion(.success(self.meters.first { $0.name == name }))
+                    return
+                }
+                if self.meters.contains(where: { $0.name == name }) {
+                    self.meters = self.meters.map { $0.name == name ? state : $0 }
+                } else {
+                    self.meters = self.meters + [state]
+                }
+                self.persistLocked(self.meters)
+                completion(.success(state))
+            }
+        }
+    }
+
+    /// MUST be called on `queue`.
+    private func persistLocked(_ value: [MeterState]) {
+        metersStore.write(account: cdpManager.currentAccountIdString(), masterId: cdpManager.currentMasterId(), value: value)
+    }
+}

--- a/CompassSDK/CDP/Models/CdpModels.swift
+++ b/CompassSDK/CDP/Models/CdpModels.swift
@@ -1,0 +1,159 @@
+//
+//  CdpModels.swift
+//  CompassSDK
+//
+//  CDP identity / profile data models. Mirrors CdpModels.kt.
+//  snake_case on the wire is handled via CodingKeys.
+//
+
+import Foundation
+
+/// CDP Recency/Frequency/Value score. Distinct from the legacy `Rfv` (which uses
+/// `rfv_r/f/v` keys and a Float score) — do not conflate the two.
+public struct CdpRfv: Codable, Equatable {
+    public let rfv: Int
+    public let r: Int
+    public let f: Int
+    public let v: Int
+
+    public init(rfv: Int, r: Int, f: Int, v: Int) {
+        self.rfv = rfv
+        self.r = r
+        self.f = f
+        self.v = v
+    }
+}
+
+internal struct CdpIdentityResponse: Decodable {
+    let masterId: String?
+    let rfv: CdpRfv?
+    let cohorts: [Int]
+
+    enum CodingKeys: String, CodingKey {
+        case masterId = "master_id"
+        case rfv
+        case cohorts
+    }
+
+    init(masterId: String?, rfv: CdpRfv?, cohorts: [Int]) {
+        self.masterId = masterId
+        self.rfv = rfv
+        self.cohorts = cohorts
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        masterId = try container.decodeIfPresent(String.self, forKey: .masterId)
+        rfv = try? container.decodeIfPresent(CdpRfv.self, forKey: .rfv)
+        cohorts = (try? container.decodeIfPresent([Int].self, forKey: .cohorts)) ?? []
+    }
+}
+
+internal struct CdpCachedIdentity {
+    let rfv: CdpRfv?
+    let cohorts: [Int]
+}
+
+internal struct CdpResolveParams: Encodable {
+    let siteId: Int
+    let cookieId: String
+    let masterId: String?
+
+    enum CodingKeys: String, CodingKey {
+        case siteId = "site_id"
+        case cookieId = "cookie_id"
+        case masterId = "master_id"
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(siteId, forKey: .siteId)
+        try container.encode(cookieId, forKey: .cookieId)
+        try container.encodeIfPresent(masterId, forKey: .masterId)
+    }
+}
+
+internal struct CdpLinkParams: Encodable {
+    let siteId: Int
+    let idType: String
+    let idValue: String
+    let isDeterministic: Bool
+    let masterId: String?
+
+    enum CodingKeys: String, CodingKey {
+        case siteId = "site_id"
+        case idType = "id_type"
+        case idValue = "id_value"
+        case isDeterministic = "is_deterministic"
+        case masterId = "master_id"
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(siteId, forKey: .siteId)
+        try container.encode(idType, forKey: .idType)
+        try container.encode(idValue, forKey: .idValue)
+        try container.encode(isDeterministic, forKey: .isDeterministic)
+        try container.encodeIfPresent(masterId, forKey: .masterId)
+    }
+}
+
+internal struct CdpProfileUpdateParams: Encodable {
+    let siteId: Int
+    let masterId: String
+    let properties: [String: String]?
+    let segmentsAdd: [String]?
+    let segmentsRemove: [String]?
+
+    enum CodingKeys: String, CodingKey {
+        case siteId = "site_id"
+        case masterId = "master_id"
+        case properties
+        case segmentsAdd = "segments_add"
+        case segmentsRemove = "segments_remove"
+    }
+
+    init(siteId: Int, masterId: String, properties: [String: String]? = nil, segmentsAdd: [String]? = nil, segmentsRemove: [String]? = nil) {
+        self.siteId = siteId
+        self.masterId = masterId
+        self.properties = properties
+        self.segmentsAdd = segmentsAdd
+        self.segmentsRemove = segmentsRemove
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(siteId, forKey: .siteId)
+        try container.encode(masterId, forKey: .masterId)
+        // Absent fields are no-ops on the backend — omit, don't send empty.
+        try container.encodeIfPresent(properties, forKey: .properties)
+        try container.encodeIfPresent(segmentsAdd, forKey: .segmentsAdd)
+        try container.encodeIfPresent(segmentsRemove, forKey: .segmentsRemove)
+    }
+}
+
+/// CDP contribution to each tracking beacon. The JSON-string forms used on the beacon
+/// are computed on demand rather than passed around as a flag.
+public struct CdpData {
+    public let masterId: String?
+    public let rfv: CdpRfv?
+    public let cohorts: [Int]
+
+    public init(masterId: String?, rfv: CdpRfv?, cohorts: [Int]) {
+        self.masterId = masterId
+        self.rfv = rfv
+        self.cohorts = cohorts
+    }
+
+    /// `{"rfv":42,"r":3,"f":5,"v":7}` or `""` when no RFV / on encoding failure.
+    public var rfvSerialized: String {
+        guard let rfv = rfv, let data = try? JSONEncoder().encode(rfv) else { return "" }
+        return String(data: data, encoding: .utf8) ?? ""
+    }
+
+    /// `[101,204]` or `"[]"` on encoding failure.
+    public var cohortsSerialized: String {
+        guard let data = try? JSONEncoder().encode(cohorts) else { return "[]" }
+        return String(data: data, encoding: .utf8) ?? "[]"
+    }
+}

--- a/CompassSDK/CDP/Models/MeterState.swift
+++ b/CompassSDK/CDP/Models/MeterState.swift
@@ -1,0 +1,107 @@
+//
+//  MeterState.swift
+//  CompassSDK
+//
+//  Server-authoritative meter (metered paywall) models. Mirrors MeterState.kt.
+//
+
+import Foundation
+
+public struct MeterWindow: Equatable {
+    public let duration: String
+    public let period: String
+    public let tz: String
+
+    public init(duration: String = "", period: String = "", tz: String = "") {
+        self.duration = duration
+        self.period = period
+        self.tz = tz
+    }
+}
+
+public struct MeterState: Equatable {
+    public let name: String
+    public let count: Int
+    /// Present only when the meter has a threshold configured. Preserve absent-vs-present.
+    public let threshold: Int?
+    public let reached: Bool?
+    public let remaining: Int?
+    public let startedAt: Date?
+    public let expiresAt: Date?
+    public let window: MeterWindow
+
+    public init(name: String, count: Int = 0, threshold: Int? = nil, reached: Bool? = nil, remaining: Int? = nil, startedAt: Date? = nil, expiresAt: Date? = nil, window: MeterWindow = MeterWindow()) {
+        self.name = name
+        self.count = count
+        self.threshold = threshold
+        self.reached = reached
+        self.remaining = remaining
+        self.startedAt = startedAt
+        self.expiresAt = expiresAt
+        self.window = window
+    }
+}
+
+/// Thrown/surfaced when an increment targets a meter not configured for the site (HTTP 404).
+public struct MeterNotFoundError: Error {
+    public let meterName: String
+    public init(meterName: String) { self.meterName = meterName }
+}
+
+extension MeterState {
+    /// Parse a raw meter object (snake_case wire shape) into a normalized `MeterState`.
+    /// The `threshold`/`reached`/`remaining` trio is present only when `threshold` exists.
+    static func from(json raw: [String: Any]) -> MeterState {
+        let windowJson = raw["window"] as? [String: Any]
+        let window = MeterWindow(
+            duration: windowJson?["duration"] as? String ?? "",
+            period: windowJson?["period"] as? String ?? "",
+            tz: windowJson?["tz"] as? String ?? ""
+        )
+
+        let hasThreshold = raw["threshold"] != nil && !(raw["threshold"] is NSNull)
+
+        return MeterState(
+            name: raw["name"] as? String ?? "",
+            count: cdpInt(raw["count"]) ?? 0,
+            threshold: hasThreshold ? cdpInt(raw["threshold"]) : nil,
+            reached: hasThreshold ? (cdpBool(raw["reached"]) ?? false) : nil,
+            remaining: hasThreshold ? (cdpInt(raw["remaining"]) ?? 0) : nil,
+            startedAt: parseIsoDate(raw["started_at"] as? String),
+            expiresAt: parseIsoDate(raw["expires_at"] as? String),
+            window: window
+        )
+    }
+
+    /// JSON-compatible dictionary for persistence (dates serialized to ISO strings).
+    func toJson() -> [String: Any] {
+        var dict: [String: Any] = [
+            "name": name,
+            "count": count,
+            "window": [
+                "duration": window.duration,
+                "period": window.period,
+                "tz": window.tz
+            ]
+        ]
+        if let threshold = threshold { dict["threshold"] = threshold }
+        if let reached = reached { dict["reached"] = reached }
+        if let remaining = remaining { dict["remaining"] = remaining }
+        if let startedAt = formatIsoDate(startedAt) { dict["started_at"] = startedAt }
+        if let expiresAt = formatIsoDate(expiresAt) { dict["expires_at"] = expiresAt }
+        return dict
+    }
+}
+
+private func cdpInt(_ value: Any?) -> Int? {
+    if let number = value as? NSNumber { return number.intValue }
+    if let int = value as? Int { return int }
+    if let string = value as? String { return Int(string) }
+    return nil
+}
+
+private func cdpBool(_ value: Any?) -> Bool? {
+    if let number = value as? NSNumber { return number.boolValue }
+    if let bool = value as? Bool { return bool }
+    return nil
+}

--- a/CompassSDK/CDP/Store/CdpMetersStore.swift
+++ b/CompassSDK/CDP/Store/CdpMetersStore.swift
@@ -1,0 +1,34 @@
+//
+//  CdpMetersStore.swift
+//  CompassSDK
+//
+//  Per-(account, master_id) meter snapshot store (dates serialized to ISO strings).
+//  Mirrors CdpMetersStore.kt.
+//
+
+import Foundation
+
+internal final class CdpMetersStore {
+    private let store: CdpMirrorStore<[MeterState]>
+
+    init(defaults: UserDefaults, clock: @escaping () -> Int64 = { Int64(Date().timeIntervalSince1970 * 1000) }) {
+        store = CdpMirrorStore<[MeterState]>(
+            defaults: defaults,
+            prefix: "cdpmeters_",
+            payloadKey: "meters",
+            serialize: { meters in meters.map { $0.toJson() } },
+            deserialize: { payload in
+                (payload as? [[String: Any]])?.map { MeterState.from(json: $0) } ?? []
+            },
+            defaultValue: [],
+            clock: clock
+        )
+    }
+
+    func read(account: String?, masterId: String?) -> [MeterState] { store.read(account: account, masterId: masterId) }
+    func write(account: String?, masterId: String?, value: [MeterState]) { store.write(account: account, masterId: masterId, value: value) }
+    func clear(account: String?, masterId: String?) { store.clear(account: account, masterId: masterId) }
+    func getActiveMid(account: String?) -> String? { store.getActiveMid(account: account) }
+    func setActiveMid(account: String?, masterId: String?) { store.setActiveMid(account: account, masterId: masterId) }
+    func cleanupExpired(account: String?, activeMidOverride: String? = nil) { store.cleanupExpired(account: account, activeMidOverride: activeMidOverride) }
+}

--- a/CompassSDK/CDP/Store/CdpMirrorStore.swift
+++ b/CompassSDK/CDP/Store/CdpMirrorStore.swift
@@ -1,0 +1,121 @@
+//
+//  CdpMirrorStore.swift
+//  CompassSDK
+//
+//  Generic TTL'd per-(account, master_id) key/value store backed by UserDefaults.
+//  Mirrors CdpMirrorStore.kt. Used by both segments and meters.
+//
+//  Envelope shape per data key: { "<payloadKey>": <payload>, "ts": <epoch_ms> }
+//
+
+import Foundation
+
+internal final class CdpMirrorStore<T> {
+    private let defaults: UserDefaults
+    private let prefix: String
+    private let payloadKey: String
+    private let serialize: (T) -> Any
+    private let deserialize: (Any) -> T
+    private let defaultValue: T
+    private let clock: () -> Int64
+
+    init(
+        defaults: UserDefaults,
+        prefix: String,
+        payloadKey: String,
+        serialize: @escaping (T) -> Any,
+        deserialize: @escaping (Any) -> T,
+        defaultValue: T,
+        clock: @escaping () -> Int64 = { Int64(Date().timeIntervalSince1970 * 1000) }
+    ) {
+        self.defaults = defaults
+        self.prefix = prefix
+        self.payloadKey = payloadKey
+        self.serialize = serialize
+        self.deserialize = deserialize
+        self.defaultValue = defaultValue
+        self.clock = clock
+    }
+
+    private func dataKey(_ account: String, _ masterId: String) -> String { "\(prefix)\(masterId)_\(account)" }
+    private func indexKey(_ account: String) -> String { "\(prefix)index_\(account)" }
+    private func activeMidKey(_ account: String) -> String { "\(prefix)active_mid_\(account)" }
+
+    func read(account: String?, masterId: String?) -> T {
+        guard let account = account, !account.isEmpty,
+              let masterId = masterId, !masterId.isEmpty else { return defaultValue }
+        guard let envelope = defaults.dictionary(forKey: dataKey(account, masterId)) else { return defaultValue }
+        guard let ts = (envelope["ts"] as? NSNumber)?.int64Value else { return defaultValue }
+        if clock() - ts >= CDP_MIRROR_TTL_MS { return defaultValue }
+        guard let payload = envelope[payloadKey] else { return defaultValue }
+        return deserialize(payload)
+    }
+
+    func write(account: String?, masterId: String?, value: T) {
+        guard let account = account, !account.isEmpty,
+              let masterId = masterId, !masterId.isEmpty else { return }
+        let envelope: [String: Any] = [
+            payloadKey: serialize(value),
+            "ts": NSNumber(value: clock())
+        ]
+        defaults.set(envelope, forKey: dataKey(account, masterId))
+        addToIndex(account: account, masterId: masterId)
+    }
+
+    func clear(account: String?, masterId: String?) {
+        guard let account = account, !account.isEmpty,
+              let masterId = masterId, !masterId.isEmpty else { return }
+        defaults.removeObject(forKey: dataKey(account, masterId))
+        var index = readIndex(account)
+        if let idx = index.firstIndex(of: masterId) {
+            index.remove(at: idx)
+            writeIndex(account, index)
+        }
+    }
+
+    func getActiveMid(account: String?) -> String? {
+        guard let account = account, !account.isEmpty else { return nil }
+        return defaults.string(forKey: activeMidKey(account))
+    }
+
+    func setActiveMid(account: String?, masterId: String?) {
+        guard let account = account, !account.isEmpty,
+              let masterId = masterId, !masterId.isEmpty else { return }
+        defaults.set(masterId, forKey: activeMidKey(account))
+    }
+
+    func cleanupExpired(account: String?, activeMidOverride: String? = nil) {
+        guard let account = account, !account.isEmpty else { return }
+        let active = activeMidOverride ?? getActiveMid(account: account)
+        let index = readIndex(account)
+        let survivors = index.filter { $0 == active || isFresh(account: account, masterId: $0) }
+        if survivors.count == index.count { return }
+
+        index.filter { !survivors.contains($0) }.forEach {
+            defaults.removeObject(forKey: dataKey(account, $0))
+        }
+        writeIndex(account, survivors)
+    }
+
+    private func isFresh(account: String, masterId: String) -> Bool {
+        guard let envelope = defaults.dictionary(forKey: dataKey(account, masterId)),
+              let ts = (envelope["ts"] as? NSNumber)?.int64Value else { return false }
+        return clock() - ts < CDP_MIRROR_TTL_MS
+    }
+
+    private func readIndex(_ account: String) -> [String] {
+        return defaults.array(forKey: indexKey(account)) as? [String] ?? []
+    }
+
+    private func writeIndex(_ account: String, _ index: [String]) {
+        defaults.set(index, forKey: indexKey(account))
+    }
+
+    private func addToIndex(account: String, masterId: String) {
+        var index = readIndex(account)
+        if !index.contains(masterId) {
+            index.append(masterId)
+            writeIndex(account, index)
+        }
+    }
+}

--- a/CompassSDK/CDP/Store/CdpSegmentsStore.swift
+++ b/CompassSDK/CDP/Store/CdpSegmentsStore.swift
@@ -1,0 +1,31 @@
+//
+//  CdpSegmentsStore.swift
+//  CompassSDK
+//
+//  Per-(account, master_id) segment store. Mirrors CdpSegmentsStore.kt.
+//
+
+import Foundation
+
+internal final class CdpSegmentsStore {
+    private let store: CdpMirrorStore<[String]>
+
+    init(defaults: UserDefaults, clock: @escaping () -> Int64 = { Int64(Date().timeIntervalSince1970 * 1000) }) {
+        store = CdpMirrorStore<[String]>(
+            defaults: defaults,
+            prefix: "cdpsegs_",
+            payloadKey: "segments",
+            serialize: { $0 },
+            deserialize: { ($0 as? [String]) ?? [] },
+            defaultValue: [],
+            clock: clock
+        )
+    }
+
+    func read(account: String?, masterId: String?) -> [String] { store.read(account: account, masterId: masterId) }
+    func write(account: String?, masterId: String?, value: [String]) { store.write(account: account, masterId: masterId, value: value) }
+    func clear(account: String?, masterId: String?) { store.clear(account: account, masterId: masterId) }
+    func getActiveMid(account: String?) -> String? { store.getActiveMid(account: account) }
+    func setActiveMid(account: String?, masterId: String?) { store.setActiveMid(account: account, masterId: masterId) }
+    func cleanupExpired(account: String?, activeMidOverride: String? = nil) { store.cleanupExpired(account: account, activeMidOverride: activeMidOverride) }
+}

--- a/CompassSDK/Info.plist
+++ b/CompassSDK/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.18.10</string>
+	<string>2.18.11</string>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 </dict>

--- a/CompassSDK/Storage/CompassStorage.swift
+++ b/CompassSDK/Storage/CompassStorage.swift
@@ -29,6 +29,10 @@ protocol CompassStorage {
     func setLandingPage(_ landingPage: String?)
     func shouldTrackConversion(_ conversion: String, id: String?) -> Bool
     func addTrackedConversion(_ conversion: String, id: String?)
+    func readCdpMasterId() -> String?
+    func writeCdpMasterId(_ newMasterId: String) -> String?
+    func readCdpCachedIdentity(sessionId: String) -> CdpCachedIdentity?
+    func writeCdpCachedIdentity(rfv: CdpRfv?, cohorts: [Int], sessionId: String)
 }
 
 enum Store: String {
@@ -51,6 +55,10 @@ class PListCompassStorage: PListStorage {
         var hasConsent: Bool?
         var landingPage: String?
         var trackedConversions: [String]?
+        var cdpMasterId: String?
+        var cdpRfv: String?
+        var cdpCohorts: String?
+        var cdpCacheSessionId: String?
 
         static var empty: Model {.init(numVisits: 0, userId: nil, suid: nil, firstVisit: nil, lastVisit: nil, userVars: Vars(), sessionVars: Vars(), userSegments: [], hasConsent: nil, landingPage: nil, trackedConversions: [])}
     }
@@ -258,6 +266,49 @@ extension PListCompassStorage: CompassStorage {
 
     private func conversionKey(_ conversion: String, id: String?) -> String {
         return id != nil ? "\(conversion):\(id!)" : conversion
+    }
+
+    // MARK: - CDP identity
+
+    /// Returns the stored master_id only if it is a valid UUID. A corrupt / non-UUID
+    /// value is transparently treated as absent (triggers a fresh resolve).
+    func readCdpMasterId() -> String? {
+        guard let id = model?.cdpMasterId, UUID(uuidString: id) != nil else { return nil }
+        return id
+    }
+
+    /// Persists a new master_id and returns the **old** (validated) value — needed for
+    /// segment carry-over when the master_id changes.
+    func writeCdpMasterId(_ newMasterId: String) -> String? {
+        let old = readCdpMasterId()
+        model?.cdpMasterId = newMasterId
+        return old
+    }
+
+    /// Session-tagged cached identity. Returns nil once the session rotates, nil if
+    /// nothing is cached, and nil if the cohorts cache is corrupt (not an array).
+    func readCdpCachedIdentity(sessionId: String) -> CdpCachedIdentity? {
+        guard model?.cdpCacheSessionId == sessionId else { return nil }
+
+        let rfvJson = model?.cdpRfv
+        let cohortsJson = model?.cdpCohorts
+
+        if rfvJson == nil && cohortsJson == nil { return nil }
+        guard let cohorts = parseCdpCohorts(cohortsJson) else { return nil }
+        let rfv = rfvJson.flatMap { CdpRfv.jsonStringDecode(from: $0) }
+
+        return CdpCachedIdentity(rfv: rfv, cohorts: cohorts)
+    }
+
+    func writeCdpCachedIdentity(rfv: CdpRfv?, cohorts: [Int], sessionId: String) {
+        model?.cdpRfv = rfv.flatMap { $0.encode() }.flatMap { String(data: $0, encoding: .utf8) }
+        model?.cdpCohorts = (cohorts.encode()).flatMap { String(data: $0, encoding: .utf8) }
+        model?.cdpCacheSessionId = sessionId
+    }
+
+    private func parseCdpCohorts(_ json: String?) -> [Int]? {
+        guard let json = json, let data = json.data(using: .utf8) else { return nil }
+        return try? JSONDecoder().decode([Int].self, from: data)
     }
 }
         

--- a/CompassSDK/Tracker/Core/CompassTracker.swift
+++ b/CompassSDK/Tracker/Core/CompassTracker.swift
@@ -135,11 +135,16 @@ public class CompassTracker: Tracker {
         }
     }
     
-    public static func initialize(accountId: Int, pageTechnology: Int? = nil, endpoint: String? = nil) {
+    public static func initialize(accountId: Int, pageTechnology: Int? = nil, endpoint: String? = nil, enableCdp: Bool = false) {
         let tracker = CompassTracker.shared
-        
+
         tracker.config.override(accountId: accountId, pageTechnology: pageTechnology, endpoint: endpoint)
+        tracker.config.cdpEnabled = enableCdp
         tracker.setDataFromConfig()
+
+        if enableCdp {
+            CdpTracker.shared.start()
+        }
     }
     
     private func setDataFromConfig() {
@@ -258,6 +263,9 @@ extension CompassTracker: CompassTracking {
 
     public func setSiteUserId(_ userId: String?) {
         trackInfo.siteUserId = userId
+        if config.cdpEnabled, let userId = userId {
+            CdpTracker.shared.onSiteUserId(userId)
+        }
     }
 
     public func getRFV(_ completion: @escaping (Rfv?) -> ()) {
@@ -292,6 +300,7 @@ extension CompassTracker: CompassTracking {
     public func trackNewPage(url: URL, rs: String? = nil) {
         restart(pageName: url.absoluteString, rs: rs)
         doTik()
+        if config.cdpEnabled { CdpTracker.shared.onNewPage() }
     }
     
     public func trackScreen(_ name: String, rs: String? = nil) {
@@ -398,6 +407,7 @@ extension CompassTracker: CompassTracking {
     
     public func setConsent(_ hasConsent: Bool) {
         storage.setConsent(hasConsent)
+        if config.cdpEnabled { CdpTracker.shared.onConsentChanged() }
     }
     
     public func getUserId() -> String {
@@ -458,6 +468,16 @@ internal extension CompassTracker {
                 finalTrackInfo.landingPage = storage.landingPage
                 finalTrackInfo.tik = tick!
 
+                // CDP beacon fields — only under personalization consent AND a master_id.
+                if config.cdpEnabled, storage.hasConsent != false {
+                    let cdpData = CdpTracker.shared.getCdpData()
+                    if let masterId = cdpData.masterId {
+                        finalTrackInfo.cdpMasterId = masterId
+                        finalTrackInfo.cdpRfv = cdpData.rfvSerialized.isEmpty ? nil : cdpData.rfvSerialized
+                        finalTrackInfo.cdpCohorts = cdpData.cohortsSerialized
+                    }
+                }
+
                 completion(finalTrackInfo)
             }
         }
@@ -492,6 +512,23 @@ internal extension CompassTracker {
     var experiencesLandingPage: String? { storage.landingPage }
     var experiencesPreviousPageUrl: String? { trackInfo.core.previosPageUrl }
     var experiencesPreviousVisitTimestamp: Int64 { storage.previousVisit?.timeStamp ?? 0 }
+
+}
+
+// MARK: - CdpHost
+// CompassTracker is the CDP's host: it stays the single owner of persistence, session,
+// consent and account config, exposed to the CDP through this narrow protocol.
+extension CompassTracker: CdpHost {
+    var cdpEnabled: Bool { config.cdpEnabled }
+    var cdpAccountId: Int? { accountId }
+    var cdpUserId: String { storage.userId }
+    var cdpSessionId: String { storage.sessionId }
+    var cdpConsent: Bool? { storage.hasConsent }
+    var cdpUserVars: [String: String] { storage.userVars }
+    func cdpReadMasterId() -> String? { storage.readCdpMasterId() }
+    func cdpWriteMasterId(_ id: String) -> String? { storage.writeCdpMasterId(id) }
+    func cdpReadCachedIdentity(sessionId: String) -> CdpCachedIdentity? { storage.readCdpCachedIdentity(sessionId: sessionId) }
+    func cdpWriteCachedIdentity(rfv: CdpRfv?, cohorts: [Int], sessionId: String) { storage.writeCdpCachedIdentity(rfv: rfv, cohorts: cohorts, sessionId: sessionId) }
 }
 
 private extension CompassTracker {
@@ -570,6 +607,7 @@ private extension CompassTracker {
         
         func onAppActive(){
             doTik()
+            if config.cdpEnabled { CdpTracker.shared.start() }
         }
         
         self.lifecyleNotifier.listen(onForeground: onAppActive, onBackground: onAppInactive)

--- a/CompassSDK/Tracker/Core/CompassTracker.swift
+++ b/CompassSDK/Tracker/Core/CompassTracker.swift
@@ -391,18 +391,22 @@ extension CompassTracker: CompassTracking {
     
     public func addUserSegment(_ name: String) {
         storage.addUserSegment(name)
+        if config.cdpEnabled { CdpTracker.shared.addCdpSegment(name) }
     }
-    
+
     public func setUserSegments(_ segments: [String]) {
         storage.addUserSegments(segments)
+        if config.cdpEnabled { CdpTracker.shared.setCdpSegments(segments) }
     }
-    
+
     public func removeUserSegment(_ name: String) {
         storage.removeUserSegment(name)
+        if config.cdpEnabled { CdpTracker.shared.removeCdpSegment(name) }
     }
-    
+
     public func clearUserSegments() {
         storage.clearUserSegments()
+        if config.cdpEnabled { CdpTracker.shared.clearCdpSegments() }
     }
     
     public func setConsent(_ hasConsent: Bool) {
@@ -529,6 +533,8 @@ extension CompassTracker: CdpHost {
     func cdpWriteMasterId(_ id: String) -> String? { storage.writeCdpMasterId(id) }
     func cdpReadCachedIdentity(sessionId: String) -> CdpCachedIdentity? { storage.readCdpCachedIdentity(sessionId: sessionId) }
     func cdpWriteCachedIdentity(rfv: CdpRfv?, cohorts: [Int], sessionId: String) { storage.writeCdpCachedIdentity(rfv: rfv, cohorts: cohorts, sessionId: sessionId) }
+    var cdpLegacySegments: [String] { storage.userSegments }
+    func cdpWriteLegacySegments(_ segments: [String]) { storage.addUserSegments(segments) }
 }
 
 private extension CompassTracker {

--- a/CompassSDK/Tracker/Core/IngestTrackInfo.swift
+++ b/CompassSDK/Tracker/Core/IngestTrackInfo.swift
@@ -21,6 +21,9 @@ struct IngestTrackInfo: Encodable {
         case conversionId = "cvid"
         case conversionValue = "cvv"
         case conversionMeta = "cvar"
+        case cdpMasterId = "cdp_mid"
+        case cdpRfv = "cdp_rfv"
+        case cdpCohorts = "cdp_cohorts"
     }
     
     private var trackInfo = TrackInfo()
@@ -43,7 +46,11 @@ struct IngestTrackInfo: Encodable {
     var conversionId: String?
     var conversionValue: String?
     var conversionMeta: [[String]]?
-    
+
+    var cdpMasterId: String?
+    var cdpRfv: String?
+    var cdpCohorts: String?
+
     public func encode(to encoder: Encoder) throws {
         var container = encoder.container(keyedBy: CodingKeys.self)
 
@@ -64,6 +71,9 @@ struct IngestTrackInfo: Encodable {
         try container.encodeIfPresent(conversionId, forKey: .conversionId)
         try container.encodeIfPresent(conversionValue, forKey: .conversionValue)
         try container.encodeIfPresent(conversionMeta, forKey: .conversionMeta)
+        try container.encodeIfPresent(cdpMasterId, forKey: .cdpMasterId)
+        try container.encodeIfPresent(cdpRfv, forKey: .cdpRfv)
+        try container.encodeIfPresent(cdpCohorts, forKey: .cdpCohorts)
     }
 }
 

--- a/CompassSDK/Tracker/Core/TrackingConfig.swift
+++ b/CompassSDK/Tracker/Core/TrackingConfig.swift
@@ -13,8 +13,9 @@ public class TrackingConfig {
     var fallbackEndpoint: URL?
     var fallbackEndpointWindow: Double?
     var pageTechnology: Int?
+    var cdpEnabled: Bool = false
     let version = "0.1"
-    
+
     public static let shared: TrackingConfig = TrackingConfig()
     
     init(bundle: Bundle = .main) {

--- a/CompassSDKTests/CdpTests.swift
+++ b/CompassSDKTests/CdpTests.swift
@@ -137,6 +137,7 @@ final class CdpTests: XCTestCase {
         var cdpUserId = "cookie"
         var cdpSessionId = "session"
         var cdpUserVars: [String: String] = [:]
+        var legacySegments: [String] = []
 
         init(enabled: Bool, consent: Bool?, account: Int?, masterId: String?) {
             self.cdpEnabled = enabled
@@ -149,6 +150,8 @@ final class CdpTests: XCTestCase {
         func cdpWriteMasterId(_ id: String) -> String? { let old = masterId; masterId = id; return old }
         func cdpReadCachedIdentity(sessionId: String) -> CdpCachedIdentity? { nil }
         func cdpWriteCachedIdentity(rfv: CdpRfv?, cohorts: [Int], sessionId: String) {}
+        var cdpLegacySegments: [String] { legacySegments }
+        func cdpWriteLegacySegments(_ segments: [String]) { legacySegments = segments }
     }
 
     private func makeManager(enabled: Bool = true, consent: Bool? = true, account: Int? = 123, masterId: String?, segmentsStore: CdpSegmentsStore) -> CdpManager {
@@ -166,6 +169,45 @@ final class CdpTests: XCTestCase {
             // Pre-identity segments land in the "local" bucket.
             XCTAssertEqual(store.read(account: "123", masterId: LOCAL_MID_SENTINEL), ["sports_fan"])
             XCTAssertEqual(manager.getCdpSegments(), ["sports_fan"])
+            expectation.fulfill()
+        }
+        wait(for: [expectation], timeout: 2)
+    }
+
+    func testMergeLegacySegmentsUnionsIntoCdpStoreAndWritesBack() {
+        let store = CdpSegmentsStore(defaults: defaults)
+        let host = MockCdpHost(enabled: true, consent: true, account: 123, masterId: "mid-1")
+        host.legacySegments = ["sports_fan", "premium"]
+        // A segment already in the CDP store (e.g. set via addCdpSegment before resolve).
+        store.write(account: "123", masterId: "mid-1", value: ["premium", "newsletter"])
+        let manager = CdpManager(api: CdpApiClient(), host: host, segmentsStore: store)
+
+        manager.mergeLegacySegments()
+
+        let expectation = XCTestExpectation(description: "merged")
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.2) {
+            // Union of CDP store + legacy, deduped.
+            XCTAssertEqual(Set(store.read(account: "123", masterId: "mid-1")), ["premium", "newsletter", "sports_fan"])
+            // Union written back to the legacy store too (bidirectional, matches web).
+            XCTAssertEqual(Set(host.legacySegments), ["premium", "newsletter", "sports_fan"])
+            expectation.fulfill()
+        }
+        wait(for: [expectation], timeout: 2)
+    }
+
+    func testMergeLegacySegmentsNoOpWithoutMasterId() {
+        let store = CdpSegmentsStore(defaults: defaults)
+        let host = MockCdpHost(enabled: true, consent: true, account: 123, masterId: nil)
+        host.legacySegments = ["sports_fan"]
+        let manager = CdpManager(api: CdpApiClient(), host: host, segmentsStore: store)
+
+        manager.mergeLegacySegments()
+
+        let expectation = XCTestExpectation(description: "noop")
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.2) {
+            // No master_id → nothing merged, legacy list untouched.
+            XCTAssertEqual(host.legacySegments, ["sports_fan"])
+            XCTAssertEqual(store.read(account: "123", masterId: LOCAL_MID_SENTINEL), [])
             expectation.fulfill()
         }
         wait(for: [expectation], timeout: 2)

--- a/CompassSDKTests/CdpTests.swift
+++ b/CompassSDKTests/CdpTests.swift
@@ -1,0 +1,190 @@
+//
+//  CdpTests.swift
+//  CompassSDKTests
+//
+//  Unit tests for the CDP subsystem's pure logic (no network):
+//  mirror-store TTL/cleanup, meter parsing, segment local-first + carry-over,
+//  fail-open response decoding, and beacon serialization.
+//
+
+import XCTest
+@testable import CompassSDK
+
+final class CdpTests: XCTestCase {
+
+    private var defaults: UserDefaults!
+    private let suiteName = "CdpTestsSuite"
+
+    override func setUp() {
+        super.setUp()
+        defaults = UserDefaults(suiteName: suiteName)
+        defaults.removePersistentDomain(forName: suiteName)
+    }
+
+    override func tearDown() {
+        defaults.removePersistentDomain(forName: suiteName)
+        defaults = nil
+        super.tearDown()
+    }
+
+    // MARK: - Mirror store
+
+    func testMirrorStoreReadWriteRoundTrip() {
+        let store = CdpSegmentsStore(defaults: defaults)
+        store.write(account: "123", masterId: "mid", value: ["a", "b"])
+        XCTAssertEqual(store.read(account: "123", masterId: "mid"), ["a", "b"])
+    }
+
+    func testMirrorStoreNoOpOnFalsyKeys() {
+        let store = CdpSegmentsStore(defaults: defaults)
+        store.write(account: nil, masterId: "mid", value: ["a"])
+        store.write(account: "123", masterId: nil, value: ["a"])
+        XCTAssertEqual(store.read(account: nil, masterId: "mid"), [])
+        XCTAssertEqual(store.read(account: "123", masterId: nil), [])
+    }
+
+    func testMirrorStoreTTLExpiry() {
+        var now: Int64 = 1_000_000
+        let store = CdpSegmentsStore(defaults: defaults, clock: { now })
+        store.write(account: "123", masterId: "mid", value: ["a"])
+        XCTAssertEqual(store.read(account: "123", masterId: "mid"), ["a"])
+
+        now += CDP_MIRROR_TTL_MS // exactly at TTL → stale
+        XCTAssertEqual(store.read(account: "123", masterId: "mid"), [])
+    }
+
+    func testCleanupNeverPurgesActiveMid() {
+        var now: Int64 = 1_000_000
+        let store = CdpSegmentsStore(defaults: defaults, clock: { now })
+        store.write(account: "123", masterId: "stale", value: ["drop"])
+
+        now += CDP_MIRROR_TTL_MS + 1 // "stale" bucket is now past TTL
+        // Write the active bucket fresh at the new "now".
+        store.write(account: "123", masterId: "active", value: ["keep"])
+
+        store.cleanupExpired(account: "123", activeMidOverride: "active")
+
+        // Active (fresh) bucket survives; stale bucket data is purged.
+        XCTAssertEqual(store.read(account: "123", masterId: "active"), ["keep"])
+        XCTAssertEqual(store.read(account: "123", masterId: "stale"), [])
+    }
+
+    // MARK: - Meter parsing
+
+    func testMeterParsingPreservesAbsentThreshold() {
+        let raw: [String: Any] = ["name": "paywall", "count": 3]
+        let meter = MeterState.from(json: raw)
+        XCTAssertEqual(meter.name, "paywall")
+        XCTAssertEqual(meter.count, 3)
+        XCTAssertNil(meter.threshold)
+        XCTAssertNil(meter.reached)
+        XCTAssertNil(meter.remaining)
+    }
+
+    func testMeterParsingWithThreshold() {
+        let raw: [String: Any] = [
+            "name": "paywall", "count": 3,
+            "threshold": 5, "reached": false, "remaining": 2,
+            "window": ["duration": "calendar", "period": "P1M", "tz": "Europe/Madrid"]
+        ]
+        let meter = MeterState.from(json: raw)
+        XCTAssertEqual(meter.threshold, 5)
+        XCTAssertEqual(meter.reached, false)
+        XCTAssertEqual(meter.remaining, 2)
+        XCTAssertEqual(meter.window.period, "P1M")
+        XCTAssertEqual(meter.window.tz, "Europe/Madrid")
+    }
+
+    func testMeterStorePersistenceRoundTrip() {
+        let store = CdpMetersStore(defaults: defaults)
+        let date = Date(timeIntervalSince1970: 1_700_000_000)
+        let meter = MeterState(name: "m", count: 4, threshold: 10, reached: false, remaining: 6, startedAt: date, window: MeterWindow(duration: "rolling", period: "P7D", tz: "UTC"))
+        store.write(account: "1", masterId: "mid", value: [meter])
+
+        let read = store.read(account: "1", masterId: "mid")
+        XCTAssertEqual(read.count, 1)
+        XCTAssertEqual(read.first?.name, "m")
+        XCTAssertEqual(read.first?.threshold, 10)
+        XCTAssertEqual(read.first?.window.period, "P7D")
+        XCTAssertNotNil(read.first?.startedAt)
+    }
+
+    // MARK: - Fail-open decoding
+
+    func testIdentityResponseDecode() {
+        let json = "{\"master_id\":\"550e8400-e29b-41d4-a716-446655440000\",\"rfv\":{\"rfv\":42,\"r\":3,\"f\":5,\"v\":7},\"cohorts\":[101,204]}"
+        let response = CdpIdentityResponse.decode(from: json.data(using: .utf8)!)
+        XCTAssertEqual(response?.masterId, "550e8400-e29b-41d4-a716-446655440000")
+        XCTAssertEqual(response?.rfv?.rfv, 42)
+        XCTAssertEqual(response?.cohorts, [101, 204])
+    }
+
+    func testIdentityResponseDecodeMissingCohorts() {
+        let json = "{\"master_id\":null,\"rfv\":null}"
+        let response = CdpIdentityResponse.decode(from: json.data(using: .utf8)!)
+        XCTAssertNil(response?.masterId)
+        XCTAssertNil(response?.rfv)
+        XCTAssertEqual(response?.cohorts, [])
+    }
+
+    // MARK: - CdpManager segment logic (local-first, carry-over)
+
+    private final class MockCdpHost: CdpHost {
+        var cdpEnabled: Bool
+        var cdpAccountId: Int?
+        var cdpConsent: Bool?
+        var masterId: String?
+        var cdpUserId = "cookie"
+        var cdpSessionId = "session"
+        var cdpUserVars: [String: String] = [:]
+
+        init(enabled: Bool, consent: Bool?, account: Int?, masterId: String?) {
+            self.cdpEnabled = enabled
+            self.cdpConsent = consent
+            self.cdpAccountId = account
+            self.masterId = masterId
+        }
+
+        func cdpReadMasterId() -> String? { masterId }
+        func cdpWriteMasterId(_ id: String) -> String? { let old = masterId; masterId = id; return old }
+        func cdpReadCachedIdentity(sessionId: String) -> CdpCachedIdentity? { nil }
+        func cdpWriteCachedIdentity(rfv: CdpRfv?, cohorts: [Int], sessionId: String) {}
+    }
+
+    private func makeManager(enabled: Bool = true, consent: Bool? = true, account: Int? = 123, masterId: String?, segmentsStore: CdpSegmentsStore) -> CdpManager {
+        let host = MockCdpHost(enabled: enabled, consent: consent, account: account, masterId: masterId)
+        return CdpManager(api: CdpApiClient(), host: host, segmentsStore: segmentsStore)
+    }
+
+    func testSegmentsWrittenLocallyToLocalBucketWithoutMasterId() {
+        let store = CdpSegmentsStore(defaults: defaults)
+        let manager = makeManager(masterId: nil, segmentsStore: store)
+        manager.addSegment("sports_fan")
+
+        let expectation = XCTestExpectation(description: "segment written")
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.2) {
+            // Pre-identity segments land in the "local" bucket.
+            XCTAssertEqual(store.read(account: "123", masterId: LOCAL_MID_SENTINEL), ["sports_fan"])
+            XCTAssertEqual(manager.getCdpSegments(), ["sports_fan"])
+            expectation.fulfill()
+        }
+        wait(for: [expectation], timeout: 2)
+    }
+
+    func testGetCdpSegmentsEmptyWhenDisabled() {
+        let store = CdpSegmentsStore(defaults: defaults)
+        store.write(account: "123", masterId: LOCAL_MID_SENTINEL, value: ["x"])
+        let manager = makeManager(enabled: false, masterId: nil, segmentsStore: store)
+        XCTAssertEqual(manager.getCdpSegments(), [])
+    }
+
+    func testGetDataDisabledReturnsEmpty() {
+        let store = CdpSegmentsStore(defaults: defaults)
+        let manager = makeManager(enabled: false, masterId: "mid", segmentsStore: store)
+        let data = manager.getData()
+        XCTAssertNil(data.masterId)
+        XCTAssertNil(data.rfv)
+        XCTAssertEqual(data.cohorts, [])
+    }
+}
+</content>

--- a/CompassSDKTests/Mocks.swift
+++ b/CompassSDKTests/Mocks.swift
@@ -123,6 +123,37 @@ class MockStorage: CompassStorage {
         }
     }
 
+    var cdpMasterId: String?
+    var cdpRfv: String?
+    var cdpCohorts: String?
+    var cdpCacheSessionId: String?
+
+    func readCdpMasterId() -> String? {
+        guard let id = cdpMasterId, UUID(uuidString: id) != nil else { return nil }
+        return id
+    }
+
+    func writeCdpMasterId(_ newMasterId: String) -> String? {
+        let old = readCdpMasterId()
+        cdpMasterId = newMasterId
+        return old
+    }
+
+    func readCdpCachedIdentity(sessionId: String) -> CdpCachedIdentity? {
+        guard cdpCacheSessionId == sessionId else { return nil }
+        if cdpRfv == nil && cdpCohorts == nil { return nil }
+        guard let json = cdpCohorts, let data = json.data(using: .utf8),
+              let cohorts = try? JSONDecoder().decode([Int].self, from: data) else { return nil }
+        let rfv = cdpRfv.flatMap { CdpRfv.jsonStringDecode(from: $0) }
+        return CdpCachedIdentity(rfv: rfv, cohorts: cohorts)
+    }
+
+    func writeCdpCachedIdentity(rfv: CdpRfv?, cohorts: [Int], sessionId: String) {
+        cdpRfv = rfv.flatMap { $0.encode() }.flatMap { String(data: $0, encoding: .utf8) }
+        cdpCohorts = cohorts.encode().flatMap { String(data: $0, encoding: .utf8) }
+        cdpCacheSessionId = sessionId
+    }
+
     init() {}
 }
 

--- a/MarfeelSDK-iOS.podspec
+++ b/MarfeelSDK-iOS.podspec
@@ -16,7 +16,7 @@ Pod::Spec.new do |spec|
   #
 
   spec.name         = "MarfeelSDK-iOS"
-  spec.version      = "2.18.10"
+  spec.version      = "2.18.11"
   spec.summary      = "iOS version of MarfeelSDK."
 
 

--- a/Playground/Playground/CdpView.swift
+++ b/Playground/Playground/CdpView.swift
@@ -1,0 +1,245 @@
+import SwiftUI
+import MarfeelSDK_iOS
+
+struct CdpView: View {
+    private let tracker = CompassTracker.shared
+    private let cdp = Cdp.shared
+
+    @State private var identitySummary = "—"
+    @State private var consentOn = true
+    @State private var siteUserId = "user@example.com"
+    @State private var linkValue = ""
+    @State private var segmentName = "sports_fan"
+    @State private var segmentsSummary = "—"
+    @State private var meterName = "paywall"
+    @State private var metersSummary = "—"
+    @State private var statusLine = ""
+
+    var body: some View {
+        NavigationView {
+            ScrollView {
+                VStack(alignment: .leading, spacing: 16) {
+                    identitySection
+                    Divider()
+                    segmentsSection
+                    Divider()
+                    metersSection
+                    if !statusLine.isEmpty {
+                        Text(statusLine)
+                            .font(.system(size: 11, design: .monospaced))
+                            .foregroundColor(.secondary)
+                    }
+                }
+                .padding()
+            }
+            .navigationTitle("CDP")
+            .onAppear(perform: refreshIdentity)
+        }
+    }
+
+    // MARK: - Identity
+
+    private var identitySection: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text("Identity").font(.headline)
+
+            Text(identitySummary)
+                .font(.system(size: 12, design: .monospaced))
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .padding(10)
+                .background(Color(.systemGray6))
+                .cornerRadius(6)
+
+            Toggle("Personalization consent", isOn: $consentOn)
+                .onChange(of: consentOn) { value in
+                    tracker.setConsent(value)
+                    status("setConsent(\(value))")
+                    refreshIdentity()
+                }
+
+            HStack {
+                Button("Track page") {
+                    tracker.trackNewPage(url: URL(string: "https://dev.marfeel.co/cdp-demo")!)
+                    status("trackNewPage → resolveIdentity")
+                    refreshLater()
+                }
+                .buttonStyle(CdpButton(color: .blue))
+
+                Button("Refresh") { refreshIdentity() }
+                    .buttonStyle(CdpButton(color: .gray))
+            }
+
+            HStack {
+                TextField("site user id", text: $siteUserId)
+                    .textFieldStyle(RoundedBorderTextFieldStyle())
+                    .autocapitalization(.none)
+                    .disableAutocorrection(true)
+                Button("setSiteUserId") {
+                    tracker.setSiteUserId(siteUserId)
+                    status("setSiteUserId → link(registered_user_id)")
+                    refreshLater()
+                }
+                .buttonStyle(CdpButton(color: .purple))
+            }
+
+            VStack(spacing: 6) {
+                TextField("email", text: $linkValue)
+                    .textFieldStyle(RoundedBorderTextFieldStyle())
+                    .autocapitalization(.none)
+                    .disableAutocorrection(true)
+                    .keyboardType(.emailAddress)
+                Button("cdpDoIdentityLink (email, deterministic)") {
+                    let value = linkValue.trimmingCharacters(in: .whitespaces)
+                    guard !value.isEmpty else { return }
+                    cdp.cdpDoIdentityLink(type: "email", value: value, isDeterministic: true)
+                    status("cdpDoIdentityLink(email, \(value))")
+                    refreshLater()
+                }
+                .buttonStyle(CdpButton(color: .purple))
+            }
+        }
+    }
+
+    // MARK: - Segments
+
+    private var segmentsSection: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text("Segments").font(.headline)
+
+            Text(segmentsSummary)
+                .font(.system(size: 12, design: .monospaced))
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .padding(10)
+                .background(Color(.systemGray6))
+                .cornerRadius(6)
+
+            TextField("segment", text: $segmentName)
+                .textFieldStyle(RoundedBorderTextFieldStyle())
+                .autocapitalization(.none)
+                .disableAutocorrection(true)
+
+            HStack {
+                Button("Add") {
+                    cdp.addCdpSegment(segmentName)
+                    status("addCdpSegment(\(segmentName))")
+                    refreshLater()
+                }.buttonStyle(CdpButton(color: .green))
+
+                Button("Remove") {
+                    cdp.removeCdpSegment(segmentName)
+                    status("removeCdpSegment(\(segmentName))")
+                    refreshLater()
+                }.buttonStyle(CdpButton(color: .orange))
+
+                Button("Set [a,b,c]") {
+                    cdp.setCdpSegments(["a", "b", "c"])
+                    status("setCdpSegments([a,b,c])")
+                    refreshLater()
+                }.buttonStyle(CdpButton(color: .blue))
+
+                Button("Clear") {
+                    cdp.clearCdpSegments()
+                    status("clearCdpSegments()")
+                    refreshLater()
+                }.buttonStyle(CdpButton(color: .red))
+            }
+        }
+    }
+
+    // MARK: - Meters
+
+    private var metersSection: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text("Meters").font(.headline)
+
+            Text(metersSummary)
+                .font(.system(size: 12, design: .monospaced))
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .padding(10)
+                .background(Color(.systemGray6))
+                .cornerRadius(6)
+
+            TextField("meter name", text: $meterName)
+                .textFieldStyle(RoundedBorderTextFieldStyle())
+                .autocapitalization(.none)
+                .disableAutocorrection(true)
+
+            HStack {
+                Button("Snapshot") {
+                    cdp.getMeterSnapshot { meters in
+                        DispatchQueue.main.async {
+                            metersSummary = format(meters: meters)
+                            status("getMeterSnapshot → \(meters.count) meters")
+                        }
+                    }
+                }.buttonStyle(CdpButton(color: .blue))
+
+                Button("Increment") {
+                    cdp.incrementMeter(meterName) { result in
+                        DispatchQueue.main.async {
+                            switch result {
+                            case .success(let meter):
+                                status("increment(\(meterName)) → count=\(meter?.count.description ?? "nil")")
+                                metersSummary = format(meters: cdp.listMeters())
+                            case .failure(let error):
+                                if error is MeterNotFoundError {
+                                    status("increment(\(meterName)) → MeterNotFoundError")
+                                } else {
+                                    status("increment(\(meterName)) → \(error.localizedDescription)")
+                                }
+                            }
+                        }
+                    }
+                }.buttonStyle(CdpButton(color: .green))
+
+                Button("List (cached)") {
+                    metersSummary = format(meters: cdp.listMeters())
+                    status("listMeters() (sync)")
+                }.buttonStyle(CdpButton(color: .gray))
+            }
+        }
+    }
+
+    // MARK: - Helpers
+
+    private func refreshIdentity() {
+        let data = cdp.getCdpData()
+        let rfv = data.rfv.map { "rfv=\($0.rfv) r=\($0.r) f=\($0.f) v=\($0.v)" } ?? "rfv=nil"
+        identitySummary = """
+        master_id: \(data.masterId ?? "nil")
+        \(rfv)
+        cohorts: \(data.cohorts)
+        """
+        segmentsSummary = "local: \(cdp.getCdpSegments())"
+    }
+
+    /// Identity/link/segment calls are async; refresh after a short delay so the UI shows
+    /// the resolved state without wiring a callback through the public fire-and-forget API.
+    private func refreshLater() {
+        DispatchQueue.main.asyncAfter(deadline: .now() + 1.0, execute: refreshIdentity)
+    }
+
+    private func format(meters: [MeterState]) -> String {
+        guard !meters.isEmpty else { return "—" }
+        return meters.map { m in
+            let threshold = m.threshold.map { "/\($0)" } ?? ""
+            return "\(m.name): \(m.count)\(threshold)"
+        }.joined(separator: "\n")
+    }
+
+    private func status(_ text: String) { statusLine = text }
+}
+
+private struct CdpButton: ButtonStyle {
+    let color: Color
+    func makeBody(configuration: Configuration) -> some View {
+        configuration.label
+            .font(.system(size: 12, weight: .semibold))
+            .padding(.horizontal, 12)
+            .padding(.vertical, 8)
+            .frame(maxWidth: .infinity)
+            .background(configuration.isPressed ? color.opacity(0.7) : color)
+            .foregroundColor(.white)
+            .cornerRadius(8)
+    }
+}

--- a/Playground/Playground/ContentView.swift
+++ b/Playground/Playground/ContentView.swift
@@ -23,6 +23,11 @@ struct ContentView: View {
                     Image(systemName: "sparkles")
                     Text("Experiences")
                 }
+            CdpView()
+                .tabItem {
+                    Image(systemName: "person.badge.key")
+                    Text("CDP")
+                }
         }
     }
 }

--- a/Playground/Playground/PlaygroundApp.swift
+++ b/Playground/Playground/PlaygroundApp.swift
@@ -24,6 +24,6 @@ struct PlaygroundApp: App {
             try? fileManager.removeItem(at: plistURL)
         }
 
-        CompassTracker.initialize(accountId: 1659, pageTechnology: 105)
+        CompassTracker.initialize(accountId: 1659, pageTechnology: 105, enableCdp: true)
     }
 }

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,5 +1,5 @@
 PODS:
-  - MarfeelSDK-iOS (2.18.4)
+  - MarfeelSDK-iOS (2.18.11)
   - SwiftUIIntrospect (1.2.0)
 
 DEPENDENCIES:
@@ -15,7 +15,7 @@ EXTERNAL SOURCES:
     :path: "."
 
 SPEC CHECKSUMS:
-  MarfeelSDK-iOS: 84a737b7770d5125894fc305532b35abe9748980
+  MarfeelSDK-iOS: 94243b26554cc6f9a7a0d754a4bcd441f2530eef
   SwiftUIIntrospect: 35fbc9ae46c869ae7290afdecf6f70c2b8c86b13
 
 PODFILE CHECKSUM: e920ba50a10ffb55ddf90460357520dd74e13f8d

--- a/Pods/Manifest.lock
+++ b/Pods/Manifest.lock
@@ -1,5 +1,5 @@
 PODS:
-  - MarfeelSDK-iOS (2.18.4)
+  - MarfeelSDK-iOS (2.18.10)
   - SwiftUIIntrospect (1.2.0)
 
 DEPENDENCIES:
@@ -15,7 +15,7 @@ EXTERNAL SOURCES:
     :path: "."
 
 SPEC CHECKSUMS:
-  MarfeelSDK-iOS: 84a737b7770d5125894fc305532b35abe9748980
+  MarfeelSDK-iOS: 6093d63ae968b1e390fd21f04cb66c5a3687bcff
   SwiftUIIntrospect: 35fbc9ae46c869ae7290afdecf6f70c2b8c86b13
 
 PODFILE CHECKSUM: e920ba50a10ffb55ddf90460357520dd74e13f8d


### PR DESCRIPTION
###  MF-8535 — CDP for iOS

  Ports the CDP subsystem to the iOS SDK. Behaviour matches the web CDP (same resolve/link/update contract, RFV/cohorts, local-first segments, SWR meters, master_id
  carry-over, consent gating); this describes the iOS-specific decisions a reviewer who knows the web version needs.

  Architecture

  New CompassSDK/CDP/ module, structured like the existing Experiences/:

  - CdpApiClient — URLSession-based, not routed through the existing ApiRouter (which forces POST, builds bodies from a param dict, and appendingPathComponent-strips the
  trailing slashes that the identity paths require). Identity/profile calls are fail-open to UNKNOWN_CDP_IDENTITY; meters are query-string GET + empty-body increment POST; 404
  on increment is surfaced distinctly.
  - CdpManager — identity state machine, segments, properties, the resolved one-shot. getData() for the beacon.
  - MeteredCounter — stale-while-revalidate mirror + increment.
  - CdpMirrorStore<T> + CdpSegmentsStore / CdpMetersStore — the generic per-(account, masterId) TTL store (180 days), backed by UserDefaults(suiteName:) (same pattern as
  FrequencyCapManager/ExperimentManager). Identity + session-tagged rfv/cohorts cache live in the existing PListCompassStorage.
  - Cdp / CdpTracking — public facade + singleton.

  iOS-specific decisions

  - No coroutines (deployment target is iOS 11). The per-session resolve memoization (web/Android use a shared in-flight promise / Deferred) is a serial DispatchQueue holding
  the resolve state + a list of pending completions that share one in-flight network call; failure resets state so the next call retries. Async surface (resolveIdentity,
  linkIdentity, getMeterSnapshot, incrementMeter) uses completion handlers; sync getters read the in-memory mirror.
  - site_id is sent as a JSON number — accountId is already Int on iOS, so the web/Android string→number coercion caveat doesn't apply.
  - No explicit "session start" event like the web page-load boundary. Resolution is driven by trackNewPage and app-foreground; the session-keyed memo makes repeat calls
  within a session no-ops, and a foreground after the 30-min session rotation re-resolves (revalidating the existing master_id).
  - master_id is UUID-validated on read; the rfv/cohorts cache is session-tagged and guards a corrupt (non-array) cohorts payload — both behave as "absent" → fresh resolve.
  - The legacy useg/rfv* segment system is untouched; CDP gets its own *CdpSegment API.

  Idiomatic-Swift choices (deliberately not 1:1 with Android)

  - The CDP reaches the tracker through a single CdpHost protocol that CompassTracker conforms to, instead of a bag of ~10 constructor closures.
  - The resolved one-shot (reconcile segments, push timezone + user-vars, seed/cleanup meters) is self-contained in CdpTracker and registered at its init, rather than passed
  in at initialize. CompassTracker.initialize(…, enableCdp:) just calls start().
  - CdpData exposes rfvSerialized/cohortsSerialized as computed properties (no serialized: Bool flag); updateProfile takes [String: String]; incrementMeter returns
  Result<MeterState?, Error>; the four segment ops share one mutateSegments helper.

  Integration points (CompassTracker)

  - initialize(accountId:pageTechnology:endpoint:enableCdp:) — new opt-in (default false); the whole subsystem is inert without it.
  - trackNewPage → invalidate meters + resolve; app foreground → start(); setSiteUserId → link registered_user_id (deterministic); setConsent → re-resolve + fire the one-shot.
  - Beacon gains cdp_mid / cdp_rfv / cdp_cohorts, attached only under personalization consent AND a present master_id.

  Gating

  enableCdp opt-in and consent (permissive unless explicitly false, matching the existing hasConsent semantics). Without both: no network, getters return empty.

  Demo

  Playground gets a CDP tab (CdpView) exercising the full public API — identity (master_id/rfv/cohorts, consent toggle, track-page, setSiteUserId, email identity-link),
  segments, and meters (snapshot/increment with MeterNotFoundError handling). CDP is enabled in the demo's initialize.

  Tests

  CdpTests covers the pure logic with no network: mirror-store TTL/cleanup (active-mid never purged), meter parse + persistence round-trip, fail-open identity decode, segment
  local-first + disabled gating.

  Notes for the reviewer

  - A few non-code housekeeping changes are in the diff: the Playground .xcodeproj now references CdpView.swift and ExperiencesView.swift (the latter was on disk but had never
  been added to the project target), and a SwiftUIIntrospect pod re-install (Podfile.lock/Pods) — its source had been an empty/broken cached download, which was blocking the
  Playground build.
  - The SDK builds via SwiftPM/CocoaPods; the CompassSDK.xcodeproj is stale (tracks neither Experiences nor CDP sources) and was intentionally left alone.